### PR TITLE
Initial build 3.2.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - sfe1ed40
+upload_channels:
+  - sfe1ed40

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,6 @@
 
 set CMAKE_GENERATOR=Ninja
-%PYTHON% setup.py install -vv --no-deps --no-build-isolation -DPython3_EXECUTABLE="%PYTHON%"
+%PYTHON% pip install -vv --no-deps --no-build-isolation
 
 set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d
 set DEACTIVATE_DIR=%PREFIX%\etc\conda\deactivate.d

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,7 +10,7 @@ curl -OL https://files.pythonhosted.org/packages/18/6c/1077b11602cac1f11e0c80a7c
 tar xvf pdal-plugins-1.1.0.tar.gz
 cd pdal-plugins-1.1.0
 
-%PYTHON% -m pip install . -v
+%PYTHON% -m pip install . --no-deps --no-build-isolation -v
 cd ../..
 
 set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,6 @@
 
 set CMAKE_GENERATOR=Ninja
-%PYTHON% setup.py install -vv -- -DPython3_EXECUTABLE="%PYTHON%"
+%PYTHON% setup.py install -vv --no-deps --no-build-isolation -DPython3_EXECUTABLE="%PYTHON%"
 
 
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,17 +1,6 @@
 
 set CMAKE_GENERATOR=Ninja
-%PYTHON% setup.py install -vv --no-deps --no-build-isolation -DPython3_EXECUTABLE="%PYTHON%"
-
-
-
-mkdir plugins
-cd plugins
-curl -OL https://files.pythonhosted.org/packages/18/6c/1077b11602cac1f11e0c80a7ca8008bf21b8d2b141c6022b56306ca407af/pdal-plugins-1.1.0.tar.gz
-tar xvf pdal-plugins-1.1.0.tar.gz
-cd pdal-plugins-1.1.0
-
-%PYTHON% -m pip install . --no-deps --no-build-isolation -v
-cd ../..
+%PYTHON% setup.py install -vv --no-deps --no-build-isolation
 
 set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d
 set DEACTIVATE_DIR=%PREFIX%\etc\conda\deactivate.d

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,6 @@
 
 set CMAKE_GENERATOR=Ninja
-%PYTHON% setup.py install -vv --no-deps --no-build-isolation
+%PYTHON% setup.py install -vv --no-deps --no-build-isolation -DPython3_EXECUTABLE="%PYTHON%"
 
 set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d
 set DEACTIVATE_DIR=%PREFIX%\etc\conda\deactivate.d

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,6 @@
 
 set CMAKE_GENERATOR=Ninja
-%PYTHON% pip install -vv --no-deps --no-build-isolation
+%PYTHON% -m pip install . -vv --no-deps --no-build-isolation
 
 set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d
 set DEACTIVATE_DIR=%PREFIX%\etc\conda\deactivate.d

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -12,17 +12,3 @@ if errorlevel 1 exit 1
 
 copy %RECIPE_DIR%\scripts\deactivate.bat %DEACTIVATE_DIR%\pdal-python-deactivate.bat
 if errorlevel 1 exit 1
-
-:: Copy unix shell activation scripts, needed by Windows Bash users
-copy %RECIPE_DIR%\scripts\activate.sh %ACTIVATE_DIR%\pdal-python-activate.sh
-if errorlevel 1 exit 1
-
-copy %RECIPE_DIR%\scripts\deactivate.sh %DEACTIVATE_DIR%\pdal-python-deactivate.sh
-if errorlevel 1 exit 1
-
-:: Copy powershell activation scripts
-copy %RECIPE_DIR%\scripts\activate.ps1 %ACTIVATE_DIR%\pdal-python-activate.ps1
-if errorlevel 1 exit 1
-
-copy %RECIPE_DIR%\scripts\deactivate.ps1 %DEACTIVATE_DIR%\pdal-python-deactivate.ps1
-if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,7 +14,7 @@ fi
 # scikit-build only passes PYTHON_EXECUTABLE and doesn't pass Python3_EXECUTABLE
 export CMAKE_ARGS="${CMAKE_ARGS} -DPDAL_DIR=$PREFIX -LAH"
 
-${PYTHON} -m pip install . -v
+${PYTHON} -m pip install . -v --no-deps --no-build-isolation
 
 mkdir plugins && cd plugins
 curl -OL https://files.pythonhosted.org/packages/66/e6/377c308a7f7d7f2a97008721e83061308a56e23f6be3b07989d44a4cfa9a/pdal-plugins-1.2.0.tar.gz

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -26,7 +26,7 @@ cd pdal-plugins-1.2.0
 #rm $BUILD_PREFIX/lib/libpython*
 #fi
 
-${PYTHON} -m pip install . -vv
+${PYTHON} -m pip install . --no-deps --no-build-isolation -vv
 cd ../..
 
 ACTIVATE_DIR=$PREFIX/etc/conda/activate.d

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,19 +16,6 @@ export CMAKE_ARGS="${CMAKE_ARGS} -DPDAL_DIR=$PREFIX -LAH"
 
 ${PYTHON} -m pip install . -v --no-deps --no-build-isolation
 
-mkdir plugins && cd plugins
-curl -OL https://files.pythonhosted.org/packages/66/e6/377c308a7f7d7f2a97008721e83061308a56e23f6be3b07989d44a4cfa9a/pdal-plugins-1.2.0.tar.gz
-tar xvf pdal-plugins-1.2.0.tar.gz
-cd pdal-plugins-1.2.0
-
-#if [ "$CONDA_BUILD_CROSS_COMPILATION" == "1" ]; then
-#rm $BUILD_PREFIX/lib/libpdal*
-#rm $BUILD_PREFIX/lib/libpython*
-#fi
-
-${PYTHON} -m pip install . --no-deps --no-build-isolation -vv
-cd ../..
-
 ACTIVATE_DIR=$PREFIX/etc/conda/activate.d
 DEACTIVATE_DIR=$PREFIX/etc/conda/deactivate.d
 mkdir -p $ACTIVATE_DIR

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
   - '10.15'                # [osx and x86_64]
   
-c_compiler:    # [win]
-- vs2019       # [win]
-cxx_compiler:  # [win]
-- vs2019       # [win]
+c_compiler:      # [win]
+  - vs2019       # [win]
+cxx_compiler:    # [win]
+  - vs2019       # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ source:
 
 build:
   number: 0
+  # Windows build fails to import. Multiple similar issues have been closed without resolution.
+  # See here: https://github.com/PDAL/python/issues/144
   skip: true  # [win or s390x or py<38]
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - make
+    - make  # [unix]
     - curl
     - cmake
     - pdal

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,17 +22,17 @@ requirements:
     - {{ compiler('cxx') }}
     - make  # [unix]
     - cmake
-    - pdal
+    - pdal 2.5.3
     - ninja
-    - scikit-build
+    - scikit-build 0.15.0
 
   host:
     - python
-    - pdal
+    - pdal 2.5.3
     - numpy
     - pip
     - pybind11
-    - scikit-build
+    - scikit-build 0.15.0
   run:
     - {{ pin_compatible('numpy') }}
     - {{ pin_compatible('pdal', max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [(win and vc<14) or (py<36) or (py<38 and linux)]
+  skip: true  # [(win and vc<14) or s390x or py<38]
 
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [(win and vc<14) or s390x or py<38]
+  skip: true  # [win or s390x or py<38]
 
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 
 build:
-  number: 2
+  number: 0
   skip: true  # [(win and vc<14) or (py<36) or (py<38 and linux)]
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/PDAL/python/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,8 +42,12 @@ requirements:
     - python
 
 test:
+  imports:
+    - pdal
+  requirements:
+    - pip
   commands:
-    - python -c "import pdal"
+    - pip check
 
 about:
   home: https://pdal.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,6 @@ build:
 
 
 requirements:
-  run_constrained:   # [osx]
-    - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}      # [osx]
   build:
     - {{ compiler('cxx') }}
     - make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,10 +23,6 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - make
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - numpy                                  # [build_platform != target_platform]
-    - pybind11                               # [build_platform != target_platform]
     - curl
     - cmake
     - pdal

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ requirements:
 test:
   imports:
     - pdal
-  requirements:
+  requires:
     - pip
   commands:
     - pip check
@@ -50,6 +50,7 @@ test:
 about:
   home: https://pdal.io
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE.txt
   summary: Point Data Abstraction Library (PDAL) Python Package
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - cmake
     - pdal 2.5.3
     - ninja
-    - scikit-build 0.15.0
 
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - make  # [unix]
-    - curl
     - cmake
     - pdal
     - ninja


### PR DESCRIPTION
[Upstream Repo](https://github.com/PDAL/python)

- Removed hardcoded `pdal-plugins` install from scripts.
- Skipped building on Windows due to unresolved issues with imports. See [here](https://github.com/PDAL/python/issues/144) and [here.](https://github.com/PDAL/python/issues/132)